### PR TITLE
Adding config-version : 2 to fix default v1 deprecated in dbt v0.19.0

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,6 @@
 name: "tutorial"
 version: "1.0.0"
+config-version: 2
 
 profile: "tutorial"
 


### PR DESCRIPTION
(see https://docs.getdbt.com/reference/project-configs/config-version)

From :
![image](https://user-images.githubusercontent.com/13470697/107707654-7e19b000-6cc2-11eb-8788-8a86b1b4b72a.png)

To : 
![image](https://user-images.githubusercontent.com/13470697/107707677-8a057200-6cc2-11eb-9c2e-135c05bfbad9.png)

