### PR TITLE
Fix deprecated functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 
 target/
-dbt_modules/
 logs/
 
 dbt_packages/

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -9,6 +9,9 @@ config-version: 2
 # This setting configures which "profile" dbt uses for this project.
 profile: sde_dbt_tutorial
 
+flags:
+  send_anonymous_usage_stats: false
+
 # These configurations specify where dbt should look
 # for different types of files.
 # The `model-paths` config, for example, states that

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -24,7 +24,7 @@ snapshot-paths: [snapshots]
 target-path: target  # directory which will store compiled SQL files
 clean-targets:  # directories to be removed by `dbt clean`
   - target
-  - dbt_modules
+  - dbt_packages
 # Configuring models
 models:
   sde_dbt_tutorial:

--- a/profiles.yml
+++ b/profiles.yml
@@ -1,6 +1,4 @@
 ---
-config:
-  send_anonymous_usage_stats: false
 sde_dbt_tutorial:
   target: dev
   outputs:


### PR DESCRIPTION
Hi @josephmachado

This is a tiny PR that removes the deprecation warnings when running `dbt clean`:

```
21:09:05  Running with dbt=1.9.6
21:09:05  [WARNING]: Deprecated functionality

User config should be moved from the 'config' key in profiles.yml to the 'flags' key in dbt_project.yml.
21:09:05  [WARNING]: Deprecated functionality
        The default package install path has changed from `dbt_modules` to
`dbt_packages`.         Please update `clean-targets` in `dbt_project.yml` and
check `.gitignore` as well.         Or, set `packages-install-path: dbt_modules`
if you'd like to keep the current value.
21:09:05  Checking /Users/xxxxxx/git/simple_dbt_project/target/*
21:09:05  Cleaned /Users/xxxxxx/git/simple_dbt_project/target/*
21:09:05  Checking /Users/xxxxxx/git/simple_dbt_project/dbt_modules/*
21:09:05  Cleaned /Users/xxxxxx/git/simple_dbt_project/dbt_modules/*
21:09:05  Finished cleaning all paths.
```

All I did was follow the instructions in the warnings to update the relevant files.

After making the changes the output of `dbt clean` looks like this:

```
21:14:55  Running with dbt=1.9.6
21:14:56  Checking /Users/xxxxxx/git/simple_dbt_project/dbt_packages/*
21:14:56  Cleaned /Users/xxxxxx/git/simple_dbt_project/dbt_packages/*
21:14:56  Checking /Users/xxxxxx/git/simple_dbt_project/target/*
21:14:56  Cleaned /Users/xxxxxx/git/simple_dbt_project/target/*
21:14:56  Finished cleaning all paths.
```

Please let me know if there's any extra info you'd like in order for this to be accepted.